### PR TITLE
fix: Added missing eventbridge attributes

### DIFF
--- a/examples/serverless/src/api.js
+++ b/examples/serverless/src/api.js
@@ -12,7 +12,9 @@ export const handler = async (event, context) => {
     await eventbridge.putEvents({
         Entries: [{
             Source: 'baselime',
-            Detail: 'too many chickens'
+            Detail: JSON.stringify({ comment: "too many chickens" }),
+            DetailType: 'comment',
+            Resources: [],
         }]
     }).promise()
     const random = Math.random();


### PR DESCRIPTION
I was poking around with baselime's lambda opentelemetry tools and that lead me to spin up the serverless project in the examples folder.

When I deployed these functions to my personal AWS account I was getting the following error 👇 

```json
{
  "Entries": [
    {
      "ErrorCode": "MalformedDetail",
      "ErrorMessage": "Detail is malformed."
    }
  ],
  "FailedEntryCount": 1
}
```

[According to AWS's docs](https://docs.aws.amazon.com/eventbridge/latest/APIReference/API_PutEventsRequestEntry.html#eventbridge-Type-PutEventsRequestEntry-DetailType) `Detail`, `DetailType`, and `Source` are all required properties.

<img width="1170" alt="Screenshot 2023-11-02 at 11 11 04 PM" src="https://github.com/baselime/lambda-node-opentelemetry/assets/1753824/06997a61-f291-4718-9352-c87798803ce0">
